### PR TITLE
Make separate folders for J+Ch4-1.2 files

### DIFF
--- a/src/simmer/image.py
+++ b/src/simmer/image.py
@@ -180,6 +180,12 @@ def create_imstack(
     if (inst.name == "ShARCS" and filt == "BrG-2.16"):
         if os.path.exists(flatfile) == False:
             flatfile = reddir + 'flat_Ks.fits'
+
+    #For ShARCS, use J flat instead of J+Ch4-1.2 if necessary
+    if (inst.name == "ShARCS" and filt == "J+Ch4-1.2"):
+        if os.path.exists(flatfile) == False:
+            flatfile = reddir + 'flat_J.fits'
+
     flat = open_flats(flatfile)
 
     skyfile = sf_dir + "sky.fits"

--- a/src/simmer/insts.py
+++ b/src/simmer/insts.py
@@ -118,6 +118,9 @@ class ShARCS(Instrument):
             filt = filter_name
         else:
             filt = head["FILT1NAM"]
+        if head["FILT2NAM"] != "Open": #append Ch4-1.2 as needed
+            filt = filt + '+'+head["FILT2NAM"]
+
         return filt
 
     def itime(self, head):

--- a/src/simmer/sky.py
+++ b/src/simmer/sky.py
@@ -130,6 +130,11 @@ def create_skies(
         if os.path.exists(flatfile) == False:
             flatfile = reddir + 'flat_Ks.fits'
 
+    #For ShARCS, use J flat instead of J+Ch4-1.2 if necessary
+    if (inst.name == "ShARCS" and filt == "J+Ch4-1.2"):
+        if os.path.exists(flatfile) == False:
+            flatfile = reddir + 'flat_J.fits'
+
     flat = pyfits.getdata(flatfile, 0)
 
     for i in range(nskies):


### PR DESCRIPTION
Properly handle observations taken in J+Ch4-1.2 by reading both filters in the FITS header and saving files accordingly.

<!--- Provide a general summary of your changes in the Title above -->

<!--- inspired by TARDIS: https://github.com/tardis-sn/tardis/edit/master/.github/PULL_REQUEST_TEMPLATE.md --->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without this fix, J+Ch4-1.2 images are lumped together with J images because only the first filter in the FITS header was read and considered when making  folders.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
